### PR TITLE
Fixing multiple eval bug in Softimage Splice again

### DIFF
--- a/FabricSpliceBaseInterface.cpp
+++ b/FabricSpliceBaseInterface.cpp
@@ -854,7 +854,7 @@ bool FabricSpliceBaseInterface::transferInputPorts(XSI::CRef opRef, OperatorCont
 
         CString singleDataType = it->second.dataType.GetSubString(0, it->second.dataType.Length()-2);
         FabricCore::RTVal arrayVal = splicePort.getRTVal();
-        uint32_t arraySize = splicePort.getArrayCount();
+        uint32_t arraySize = arrayVal.getArraySize();
         for(int i=0; ; i++)
         {
           CValue value = context.GetInputValue(portName.c_str()+CString(i));
@@ -891,7 +891,7 @@ bool FabricSpliceBaseInterface::transferInputPorts(XSI::CRef opRef, OperatorCont
         getRTValFromCMatrix4(matrix, rtVal);
 
         FabricCore::RTVal currVal = splicePort.getRTVal();
-        if(!currVal.callMethod("Boolean", "equal", 1, &rtVal).getBoolean()){
+        if(!currVal.callMethod("Boolean", "almostEqual", 1, &rtVal).getBoolean()){
           splicePort.setRTVal(rtVal);
           addDirtyInput(portName, evalContext, -1);
           result = true;
@@ -919,7 +919,7 @@ bool FabricSpliceBaseInterface::transferInputPorts(XSI::CRef opRef, OperatorCont
           else
           {
             FabricCore::RTVal currVal = arrayVal.getArrayElement(i);
-            if(!currVal.callMethod("Boolean", "equal", 1, &rtVal).getBoolean()){
+            if(!currVal.callMethod("Boolean", "almostEqual", 1, &rtVal).getBoolean()){
               arrayVal.setArrayElement(i, rtVal);
               addDirtyInput(portName, evalContext, i);
               result = true;
@@ -1109,7 +1109,7 @@ CStatus FabricSpliceBaseInterface::transferOutputPort(OperatorContext & context)
     {
       CString singleDataType = it->second.dataType.GetSubString(0, it->second.dataType.Length()-2);
       FabricCore::RTVal rtVal = splicePort.getRTVal();
-      uint32_t arraySize = splicePort.getArrayCount();
+      uint32_t arraySize = rtVal.getArraySize();
       uint32_t portIndex = xsiPort.GetIndex();
       uint32_t arrayIndex = UINT_MAX;
       for(LONG i=0;i<it->second.portIndices.GetCount();i++)
@@ -1142,7 +1142,7 @@ CStatus FabricSpliceBaseInterface::transferOutputPort(OperatorContext & context)
     else if(it->second.dataType == "Mat44[]")
     {
       FabricCore::RTVal rtVal = splicePort.getRTVal();
-      uint32_t arraySize = splicePort.getArrayCount();
+      uint32_t arraySize = rtVal.getArraySize();
       uint32_t portIndex = xsiPort.GetIndex();
       uint32_t arrayIndex = UINT_MAX;
       for(LONG i=0;i<it->second.portIndices.GetCount();i++)


### PR DESCRIPTION
While debugging performance problems in Kraken, I discovered that a side effect of DGPortImpl::getArrayCount is that it forces an evaluation which was causing evaluations to occur when data was being transferred from the out ports back to Softimage.

```
  if(!node->evaluate(mDGNode, errorOut))
    return 0;
```

Note: getArrayCount should be fixed to not force evaluations. These evaluations can be quite expensive, and can be triggered many times during a single scene evaluation. I noticed that the SpliceMaya integration invokes getArrayCount in many places, so I assume there are many redundant evaluations occurring there too. 

Also: If getArrayCount is being called in the 'transferInputs' stage, then the KL code is being evaluated before all inputs are transferred, which will lead to very hard to debug problems. 


 - Avoiding using splicePort.getArrayCount because it forces an evaluation.
 - Also using almostEqual to avoid evaluations due to floating point precision issues.

there is a bug open for this, so you can probably close the bug after merging this.